### PR TITLE
Added check for equal types in IFluidityRepository.Get() method

### DIFF
--- a/src/Fluidity/Data/FluidityRepository`T.cs
+++ b/src/Fluidity/Data/FluidityRepository`T.cs
@@ -162,7 +162,17 @@ namespace Fluidity.Data
 
         object IFluidityRepository.Get(object id, bool fireEvents)
         {
-            return Get((TId)TypeDescriptor.GetConverter(typeof(TId)).ConvertFrom(id), fireEvents);
+            // Check if the specified Identifier type is the same type as the "id" arguement.
+            // If it is, then we don't need to convert this value.
+            // Otherwise, we will need to convert the "id" to the specified type.
+            if(typeof(TId) == id.GetType())
+            {
+                return Get((TId)id, fireEvents);
+            }
+            else
+            {
+                return Get((TId)TypeDescriptor.GetConverter(typeof(TId)).ConvertFrom(id), fireEvents);
+            }
         }
 
         IEnumerable<object> IFluidityRepository.GetAll(bool fireEvents)


### PR DESCRIPTION
I have encountered an issue when implementing a custom repository.

I have created a repository implementation as outlined in the documentation, to retrieve and update data from a separate database using Entity Framework. 

This all seems to be OK up until a point, as I can retrieve the data fine using my custom repository and the relevant items get listed in the tree. As well as being presented in the editor with the data pre-filled in the form.

However, it is not until I try to save the data back to the database that I get the following error:

```
System.NotSupportedException: 'Int32Converter cannot convert from System.Int32.'
```

This error occurs on line 165 of the file `.\src\Fluidity\Data\FluidityRepository`T.cs`, which is the following code:

```
object IFluidityRepository.Get(object id, bool fireEvents)
{
    return Get((TId)TypeDescriptor.GetConverter(typeof(TId)).ConvertFrom(id), fireEvents);
}
```

As a result of this, the `SaveImpl()` method on my custom repository is never triggered.

The custom repository I am using has defined the Identifier type as an `int`. As a result it seems that the code on the line/file mentioned above is trying to convert an Int32 to an Int32, which it doesn't need to do in this case as it is already the correct type. I believe in this scenario, it just needs to cast `object` to `int`.

I have created a repository with a Sample Web App to demonstrate this issue:

https://github.com/xrisdoc/FluiditySampleWebApp

Steps to reproduce:

1. Clone Repository
2. Open Solution in Visual Studio
3. Build Solution
4. Run the Web Application
5. Navigate to the Umbraco back office
6. Login using the following credentials: 

* Username: admin@test.com
* Password: Password1!

7. Navigate to **_Print Admin_** > **_Printers_** > **_[Select a Printer from the list]_**
8. Printer form should be displayed
9. Edit values in the form and click the Save button
10. Error should occur and displayed in the red alert box at the bottom of the page.

**Note:** The sample uses LocalDB and database files are provided for this sample.  But if you need to use SQLExpress, then you should only need to update the connection string in the Web.config file. It uses code first, so should generate the relevant database and seed data.

This Pull Request adds a check in the `IFluidityRepository.Get(object id, bool fireEvents)` method.

This checks if the specified Identifier type is the same as the `id` type. If this is the case, then the `id` is cast to the specified type.

Otherwise, the relevant converter is obtained for the type and relevant value is converted using this converter.

This seems to fix the issue I have encountered. I have also tested this with the standard PetaPoco approach and seems to work as expected too.