### PR TITLE
Supports updating of entities with Guid primary keys

### DIFF
--- a/src/Fluidity/Data/FluidityRepository`T.cs
+++ b/src/Fluidity/Data/FluidityRepository`T.cs
@@ -171,7 +171,7 @@ namespace Fluidity.Data
             }
             else
             {
-                return Get((TId)TypeDescriptor.GetConverter(typeof(TId)).ConvertFrom(id), fireEvents);
+                return Get((TId)TypeDescriptor.GetConverter(typeof(TId)).ConvertFrom(id.ToString()), fireEvents);
             }
         }
 


### PR DESCRIPTION
I ran into an issue when trying to update a database entity that has a Guid as its primary key. Exception that was thrown is as follows: 

`System.NotSupportedException: GuidConverter cannot convert from System.Guid.`

The update in this pull request ensures that a type converter uses the ToString value of an entities Id property. Entities with a Guid primary key could be updated successfully afterwards.

I also tested this update using an entity with an integer primary key, similar to the one used the "Getting Started" part of fluidity's documentation, and didn't run into any issues.

I'm fairly new to pull requests and how they work, so if I've done anything wrong here let me know :)