### PR TITLE
Fixes #27 - Entity picker fails when collection doesn't have listview configured

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 os: Visual Studio 2015
 
 # version format
-version: 1.0.1.{build}
+version: 1.0.2.{build}
 
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
   - nuget restore src
 
 build_script:
-- build-appveyor.cmd
+  - build-appveyor.cmd
 
 artifacts:
   - path: artifacts\*.nupkg
@@ -47,7 +47,7 @@ deploy:
   - provider: NuGet
     server: 
     api_key:
-      secure: eSLiOXbGVrxSG+X7PV6qTTUZ5VzS9EFj5+EufaWPfd+QXkF6gc8rZ4mGoHIVp/fL
+      secure: 0+oAleUTnr9UuJrhLW5rphRR+QGz00XX1Ui3k5kwyr2kUdEamiQ3F+gW0q8MJbDT
     artifact: /.*\.nupkg/
     on:
       branch: master

--- a/docs/_pages/04-reference-01-known-issues.md
+++ b/docs/_pages/04-reference-01-known-issues.md
@@ -11,7 +11,7 @@ Fluidity tries it's best to mimc the content pipeline as closely as possible whi
 
 #### Tags  
 
-Whilst we have support for persisting the tags value, we don't currently have the ability to write these tags to the `cmsTags` DB table. Unfortunately this is all handled internally via a `tagsRepository` which is internal and so we currently can't save to it like core does.
+Whilst we have support for persisting the tags value, we don't currently have the ability to write these tags to the `cmsTags` DB table. Unfortunately this is all handled via a `tagsRepository` which is internal and so we currently can't save to it like core does.
 
 ### Multi Node Tree Picker
 

--- a/docs/_pages/04-reference-01-known-issues.md
+++ b/docs/_pages/04-reference-01-known-issues.md
@@ -13,3 +13,6 @@ Fluidity tries it's best to mimc the content pipeline as closely as possible whi
 
 Whilst we have support for persisting the tags value, we don't currently have the ability to write these tags to the `cmsTags` DB table. Unfortunately this is all handled internally via a `tagsRepository` which is internal and so we currently can't save to it like core does.
 
+### Multi Node Tree Picker
+
+When using a Multi Node Tree Picker with an XPath filter, only filters starting with the `$root` placeholder will be valid as all other placeholders expect the property editor to be placed on a content node, with that node being used as context.

--- a/src/Fluidity/Configuration/FluidityPropertyConfig.cs
+++ b/src/Fluidity/Configuration/FluidityPropertyConfig.cs
@@ -44,7 +44,7 @@ namespace Fluidity.Configuration
         /// </returns>
         public static implicit operator PropertyInfo(FluidityPropertyConfig propertyConfig)
         {
-            return propertyConfig.PropertyInfo;
+            return propertyConfig?.PropertyInfo;
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Fluidity.Configuration
         /// </returns>
         public static implicit operator LambdaExpression(FluidityPropertyConfig propertyConfig)
         {
-            return propertyConfig.PropertyExpression;
+            return propertyConfig?.PropertyExpression;
         }
 
         /// <summary>

--- a/src/Fluidity/Web/Models/FluidityListViewDisplayModel.cs
+++ b/src/Fluidity/Web/Models/FluidityListViewDisplayModel.cs
@@ -15,6 +15,12 @@ namespace Fluidity.Web.Models
         [DataMember(Name = "pageSize")]
         public int PageSize { get; set; }
 
+        [DataMember(Name = "defaultOrderBy")]
+        public string DefaultOrderBy { get; set; }
+
+        [DataMember(Name = "defaultOrderDirection")]
+        public string DefaultOrderDirection { get; set; }
+
         [DataMember(Name = "bulkActions")]
         public IEnumerable<FluidityListViewBulkActionDisplayModel> BulkActions { get; set; }
 

--- a/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
@@ -32,7 +32,7 @@ namespace Fluidity.Web.Models.Mappers
                 Path = collection.Path
             };
 
-            if (includeListView)
+            if (includeListView && m.HasListView)
             {
                 m.ListView = new FluidityListViewDisplayModel
                 {

--- a/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
@@ -37,6 +37,8 @@ namespace Fluidity.Web.Models.Mappers
                 m.ListView = new FluidityListViewDisplayModel
                 {
                     PageSize = collection.ListView.PageSize,
+                    DefaultOrderBy = collection.SortProperty?.Name ?? "Name",
+                    DefaultOrderDirection = collection.SortDirection == SortDirection.Ascending ? "asc" : "desc",
                     Properties = collection.ListView.Fields.Select(x =>
                     {
                         // Calculate heading

--- a/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityEntityMapper.cs
@@ -69,29 +69,27 @@ namespace Fluidity.Web.Models.Mappers
                 EditPath = $"{section.Alias}/fluidity/edit/{entityCompositeId}",
             };
 
-            if (collection.Editor?.Tabs != null)
+            if (collection.ListView != null)
             {
                 var properties = new List<ContentPropertyBasic>();
-                if (collection.ListView != null)
+
+                foreach (var field in collection.ListView.Fields)
                 {
-                    foreach (var field in collection.ListView.Fields)
+                    var value = entity?.GetPropertyValue(field.Property);
+
+                    if (field.Format != null)
                     {
-                        var value = entity?.GetPropertyValue(field.Property);
-
-                        if (field.Format != null)
-                        {
-                            value = field.Format(value, entity);
-                        }
-
-                        var propertyScaffold = new ContentPropertyBasic
-                        {
-                            Id = properties.Count,
-                            Alias = field.Property.Name,
-                            Value = value?.ToString()
-                        };
-
-                        properties.Add(propertyScaffold);
+                        value = field.Format(value, entity);
                     }
+
+                    var propertyScaffold = new ContentPropertyBasic
+                    {
+                        Id = properties.Count,
+                        Alias = field.Property.Name,
+                        Value = value?.ToString()
+                    };
+
+                    properties.Add(propertyScaffold);
                 }
 
                 display.Properties = properties;

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/backoffice/fluidity/list.controller.js
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/backoffice/fluidity/list.controller.js
@@ -22,6 +22,8 @@
             options: {
                 isSearchable: true,
                 pageSize: 10,
+                defaultOrderBy: "Name",
+                defaultOrderDirection: "desc",
                 bulkActions: [],
                 dataViews: [],
                 layouts: [],
@@ -34,12 +36,14 @@
 
         function init(collection) {
             $scope.page.name = collection.namePlural;
-            $scope.listView.options.isSearchable = collection.isSearchable;
-            $scope.listView.options.pageSize     = collection.listView.pageSize;
-            $scope.listView.options.bulkActions  = collection.listView.bulkActions;
-            $scope.listView.options.dataViews    = collection.listView.dataViews;
-            $scope.listView.options.layouts      = collection.listView.layouts;
-            $scope.listView.options.properties   = collection.listView.properties;
+            $scope.listView.options.isSearchable          = collection.isSearchable;
+            $scope.listView.options.pageSize              = collection.listView.pageSize;
+            $scope.listView.options.defaultOrderBy        = collection.listView.defaultOrderBy;
+            $scope.listView.options.defaultOrderDirection = collection.listView.defaultOrderDirection;
+            $scope.listView.options.bulkActions           = collection.listView.bulkActions;
+            $scope.listView.options.dataViews             = collection.listView.dataViews;
+            $scope.listView.options.layouts               = collection.listView.layouts;
+            $scope.listView.options.properties            = collection.listView.properties;
         }
 
         function syncTree(entity, path, initialLoad) {

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/directives/listview.directive.js
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/directives/listview.directive.js
@@ -24,8 +24,8 @@
             $scope.options = angular.extend({}, {
                 pageNumber: ($routeParams.page && Number($routeParams.page) != NaN && Number($routeParams.page) > 0) ? $routeParams.page : 1,
                 pageSize: $scope.opts.pageSize,
-                orderBy: "name",
-                orderDirection: "desc",
+                orderBy: $scope.opts.defaultOrderBy || "name",
+                orderDirection: $scope.opts.defaultOrderDirection || "desc",
                 filter: '', // Variable has to be named "filter" to work with list view properly
                 dataView: fluidityUtilityService.recallDataView($routeParams.id, $scope.opts.dataViews), // TODO: Remember the dataview like how the layout persists
                 dataViews: $scope.opts.dataViews,

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/overrides/fluidity.overrides.js
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/overrides/fluidity.overrides.js
@@ -90,7 +90,7 @@
             // intercept the call and just set it to the root id.
             var oldGetByQuery = $delegate.getByQuery;
             $delegate.getByQuery = function () {
-                if (arguments.length >= 2 && arguments[1].indexOf('!') >= 0) { // '!' signifies a fluidity composite id
+                if (arguments.length >= 2 && arguments[1].toString().indexOf('!') >= 0) { // '!' signifies a fluidity composite id
                     arguments[1] = -1;
                 }
                 return oldGetByQuery.apply($delegate, arguments);

--- a/src/Fluidity/Web/UI/App_Plugins/Fluidity/overrides/fluidity.overrides.js
+++ b/src/Fluidity/Web/UI/App_Plugins/Fluidity/overrides/fluidity.overrides.js
@@ -78,4 +78,30 @@
 
     angular.module("umbraco.services").config(['$provide', fluidityUmbracoServicesOverrides]);
 
+    // Umbraco resource overrides
+    function fluidityUmbracoResourceOverrides($provide) {
+
+        $provide.decorator('entityResource', function ($delegate) {
+
+            // When using MNTP with an xpath filter with fluidity
+            // a call to getByQuery is made using the $routeParams.id
+            // as context. Unfortunately it expects that variable to
+            // be an int, which in fluidity's case is not, so we 
+            // intercept the call and just set it to the root id.
+            var oldGetByQuery = $delegate.getByQuery;
+            $delegate.getByQuery = function () {
+                if (arguments.length >= 2 && arguments[1].indexOf('!') >= 0) { // '!' signifies a fluidity composite id
+                    arguments[1] = -1;
+                }
+                return oldGetByQuery.apply($delegate, arguments);
+            };
+
+            return $delegate;
+
+        });
+
+    }
+
+    angular.module("umbraco.resources").config(['$provide', fluidityUmbracoResourceOverrides]);
+
 })();


### PR DESCRIPTION
I added a check to avoid a null reference if the collection view is not a list.