### PR TITLE
Fixes #27 - Entity picker fails when collection doesn't have listview configured 

### DIFF
--- a/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
+++ b/src/Fluidity/Web/Models/Mappers/FluidityCollectionMapper.cs
@@ -32,7 +32,7 @@ namespace Fluidity.Web.Models.Mappers
                 Path = collection.Path
             };
 
-            if (includeListView)
+            if (includeListView && m.HasListView)
             {
                 m.ListView = new FluidityListViewDisplayModel
                 {


### PR DESCRIPTION
I added a check to avoid a null reference if the collection view is not a list.