### PR TITLE
Fixes #26 wrong node name

### DIFF
--- a/src/Fluidity/Web/Trees/FluidityTreeController.cs
+++ b/src/Fluidity/Web/Trees/FluidityTreeController.cs
@@ -253,11 +253,14 @@ namespace Fluidity.Web.Trees
             var itemId = entity.GetPropertyValue(collection.IdProperty);
             var compositeId = collection.Alias + "!" + itemId;
 
+            var entityName = collection.NameProperty != null ? entity.GetPropertyValue(collection.NameProperty).ToString()
+                                : collection.NameFormat != null ? collection.NameFormat(entity) : entity.ToString();
+
             var node = CreateTreeNode(
                 compositeId,
                 collection.Alias,
                 queryStrings,
-                collection.NameFormat != null ? collection.NameFormat(entity) : entity.ToString(),
+                entityName,
                 collection.IconSingular,
                 false,
                 SectionAlias + "/fluidity/edit/" + compositeId);


### PR DESCRIPTION
Node name was using only NameFormat to get the value. I modifed the logic so it uses NameProperty if set or falls back to NameFormat if not.