### PR TITLE
Made FluidityRepository disposable

### DIFF
--- a/src/Fluidity/Data/DefaultFluidityRepository.cs
+++ b/src/Fluidity/Data/DefaultFluidityRepository.cs
@@ -217,5 +217,10 @@ namespace Fluidity.Data
 
             return Db.ExecuteScalar<long>(query);
         }
+
+        public void Dispose()
+        {
+            //No disposable resources
+        }
     }
 }

--- a/src/Fluidity/Data/FluidityRepository`T.cs
+++ b/src/Fluidity/Data/FluidityRepository`T.cs
@@ -20,7 +20,7 @@ namespace Fluidity.Data
     /// <typeparam name="TEntity">The type of the entity.</typeparam>
     /// <typeparam name="TId">The type of the identifier.</typeparam>
     /// <seealso cref="Fluidity.Data.IFluidityRepository" />
-    public abstract class FluidityRepository<TEntity, TId> : IFluidityRepository
+    public abstract class FluidityRepository<TEntity, TId> : IFluidityRepository, IDisposable
     {
         public virtual Type EntityType => typeof(TEntity);
         public virtual Type IdType => typeof(TId);
@@ -206,5 +206,10 @@ namespace Fluidity.Data
         }
 
         #endregion
+
+        public virtual void Dispose()
+        {
+            //No resources to dispose of by default
+        }
     }
 }

--- a/src/Fluidity/Data/FluidityRepository`T.cs
+++ b/src/Fluidity/Data/FluidityRepository`T.cs
@@ -20,7 +20,7 @@ namespace Fluidity.Data
     /// <typeparam name="TEntity">The type of the entity.</typeparam>
     /// <typeparam name="TId">The type of the identifier.</typeparam>
     /// <seealso cref="Fluidity.Data.IFluidityRepository" />
-    public abstract class FluidityRepository<TEntity, TId> : IFluidityRepository, IDisposable
+    public abstract class FluidityRepository<TEntity, TId> : IFluidityRepository
     {
         public virtual Type EntityType => typeof(TEntity);
         public virtual Type IdType => typeof(TId);

--- a/src/Fluidity/Data/IFluidityRepository.cs
+++ b/src/Fluidity/Data/IFluidityRepository.cs
@@ -11,7 +11,7 @@ using Umbraco.Core.Models;
 namespace Fluidity.Data
 {
     [Obsolete("Use the abstract class FluidityRepository<TEntity, TId> instead")]
-    public interface IFluidityRepository
+    public interface IFluidityRepository : IDisposable
     {
         Type EntityType { get; }
 


### PR DESCRIPTION
My FluidityRepository implementation would ideally be IDisposable, as it uses a disposable resource. This PR makes `IFluidityRepository` and `FluidityRepository<TEntity, TId>` disposable, though the default repository disposes of nothing. I added it to both only because`IFluidityRepository` is marked as obsolete, thought it is clearly widely used so perhaps this is unnecessary.

Additionally where an `IFluidityRepository` object is instantiated I've disposed of the object after use.

This was really quick to achieve. Please know that I take absolutely no offence if you think it isn't a useful inclusion. 