### PR TITLE
Minor typo in documentation (suplied -> supplied)

### DIFF
--- a/docs/_pages/02-api-06-data-views-builders.md
+++ b/docs/_pages/02-api-06-data-views-builders.md
@@ -22,7 +22,7 @@ public class PersonDataViewsBuilder : FluidityDataViewsBuilder<Person>
 
     public override Expression<Func<Person, bool>> GetDataViewWhereClause(string dataViewAlias)
     {
-        // Return a where clause expression for the suplied data view alias
+        // Return a where clause expression for the supplied data view alias
     }
 }
 ````


### PR DESCRIPTION
Really minor typo that I caught while looking through the docs (which are awesome by the way!)