### PR TITLE
Documentation Typo: SetHeadng -> SetHeading

### DIFF
--- a/docs/_pages/02-api-04-collections-00-list-view.md
+++ b/docs/_pages/02-api-04-collections-00-list-view.md
@@ -131,7 +131,7 @@ listViewConfig.AddField(p => p.FirstName, fieldConfig => {
 ### Changing the heading of a field
 {: .mt}
 
-#### SetHeadng(string heading) *: FluidityListViewFieldConfig&lt;TEntityType, TValueType&gt;*
+#### SetHeading(string heading) *: FluidityListViewFieldConfig&lt;TEntityType, TValueType&gt;*
 {: .signature}
 
 Sets the heading for the list view field.


### PR DESCRIPTION
Really small typo in the List View documentation.